### PR TITLE
Fill missing URL Scheme.

### DIFF
--- a/etcd/client.go
+++ b/etcd/client.go
@@ -148,6 +148,9 @@ func (c *Client) internalSyncCluster(machines []string) bool {
 func (c *Client) createHttpPath(serverName string, _path string) string {
 	u, _ := url.Parse(serverName)
 	u.Path = path.Join(u.Path, "/", _path)
+	if u.Scheme == "" {
+		u.Scheme = "http"
+	}
 	return u.String()
 }
 


### PR DESCRIPTION
Now you can use just `127.0.0.1:4001` for example :)
