### PR TITLE
Added ErrUserStopped variable to catch when the library is no longer watching a key

### DIFF
--- a/etcd/watch.go
+++ b/etcd/watch.go
@@ -16,6 +16,9 @@ type respAndErr struct {
 	err  error
 }
 
+// ErrUserStopped means the watch goroutine was cancelled by the user (by sending a value on the stop channel)
+var ErrUserStopped = errors.New("User stoped watch")
+
 // Watch any change under the given prefix.
 // When a sinceIndex is given, watch will try to scan from that index to the last index
 // and will return any changes under the given prefix during the history
@@ -66,7 +69,7 @@ func (c *Client) watchOnce(key string, sinceIndex uint64, stop chan bool) (*stor
 			resp, err = res.resp, res.err
 
 		case <-stop:
-			resp, err = nil, errors.New("User stoped watch")
+			resp, err = nil, ErrUserStopped
 		}
 	} else {
 		resp, err = c.sendWatchRequest(key, sinceIndex)


### PR DESCRIPTION
Currently I am using this pattern for key watching:

``` go
go func(responseChannel chan *store.Response) {
    for response := range updateNodes {
        // do some work with new response
    }
}(responseChannel)

go func(responseChannel chan *store.Response, stopChannel chan bool) {
    for {
        _, e := as.Etcd.Watch("mykey/x", 0, responseChannel, stopChannel)
        if e.Error() == "User stoped watch" {
            break
        } else {
            log.Print("Error watching: ", e)
        }
    }
    close(responseChannel)
}(responseChannel, stopChannel)
/// do some work
stopChannel <- true
```

This way I can watch a key, and if the machine I'm listening on were to close for any other reason that I cancelled it, 
it would attempt to watch the key again. What this pull request does is adds a `ErrUserStopped error` to the package so instead of 

`if e.Error() == "User stoped watch" {` 

I can write

`if e == etcd.ErrUserStopped {`

which I believe is more idiomatic. I kept the messages the same so that the previous code still works.
