### PR TITLE
Close response body when there's an Internal Server Error

### DIFF
--- a/etcd/client.go
+++ b/etcd/client.go
@@ -236,11 +236,12 @@ func (c *Client) sendRequest(method string, _path string, body string) (*http.Re
 				// try to connect the leader
 				continue
 			} else if resp.StatusCode == http.StatusInternalServerError {
+				resp.Body.Close()
+
 				retry++
 				if retry > 2*len(c.cluster.Machines) {
 					return nil, errors.New("Cannot reach servers")
 				}
-				resp.Body.Close()
 				continue
 			} else {
 				logger.Debug("send.return.response ", httpPath)


### PR DESCRIPTION
There's an edge case where when the server responds with a 500 error and we've exceeded our retry count, the response body won't be closed leading to a leaked file descriptor.

It's quite hard to reproduce as it requires your etcd server to send 500 errors, which in my case was caused by the raft server timing out in a cluster due to [etcd#176](https://github.com/coreos/etcd/issues/176).

When my server was in an inconsistent state, it would eventually run out of file descriptors because my services would be hitting etcd and leaking a descriptor for every 500 error received.
