### PR TITLE
fix(cluster): SyncCluster was broken

### DIFF
--- a/etcd/client.go
+++ b/etcd/client.go
@@ -111,6 +111,10 @@ func (c *Client) SetCluster(machines []string) bool {
 	return success
 }
 
+func (c *Client) GetCluster() []string {
+	return c.cluster.Machines
+}
+
 // sycn cluster information using the existing machine list
 func (c *Client) SyncCluster() bool {
 	success := c.internalSyncCluster(c.cluster.Machines)
@@ -132,8 +136,9 @@ func (c *Client) internalSyncCluster(machines []string) bool {
 				// try another machine in the cluster
 				continue
 			}
+
 			// update Machines List
-			c.cluster.Machines = strings.Split(string(b), ",")
+			c.cluster.Machines = strings.Split(string(b), ", ")
 
 			// update leader
 			// the first one in the machine list is the leader

--- a/etcd/client_test.go
+++ b/etcd/client_test.go
@@ -3,6 +3,8 @@ package etcd
 import (
 	"fmt"
 	"testing"
+	"net/url"
+	"net"
 )
 
 // To pass this test, we need to create a cluster of 3 machines
@@ -15,6 +17,24 @@ func TestSync(t *testing.T) {
 	success := c.SyncCluster()
 	if !success {
 		t.Fatal("cannot sync machines")
+	}
+
+	for _, m := range(c.GetCluster()) {
+		u, err := url.Parse(m)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if u.Scheme != "http" {
+			t.Fatal("scheme must be http")
+		}
+		
+		host, _, err := net.SplitHostPort(u.Host)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if host != "127.0.0.1" {
+			t.Fatal("Host must be 127.0.0.1")
+		}
 	}
 
 	badMachines := []string{"abc", "edef"}

--- a/examples/sync-cluster/README.md
+++ b/examples/sync-cluster/README.md
@@ -1,0 +1,3 @@
+Example script from the sync-cluster bug https://github.com/coreos/go-etcd/issues/27
+
+TODO: turn this into a test case

--- a/examples/sync-cluster/sync-cluster.go
+++ b/examples/sync-cluster/sync-cluster.go
@@ -1,0 +1,51 @@
+
+package main
+
+import (
+	"fmt"
+	"github.com/coreos/go-etcd/etcd"
+	"strconv"
+	"time"
+)
+
+func main() {
+	fmt.Println("etcd-client started")
+	c := etcd.NewClient(nil)
+	c.SetCluster([]string{
+		"http://127.0.0.1:4001",
+		"http://127.0.0.1:4002",
+		"http://127.0.0.1:4003",
+	})
+
+	ticker := time.NewTicker(time.Second * 3)
+
+	for {
+		select {
+		case d := <-ticker.C:
+			n := d.Second()
+			if n <= 0 {
+				n = 60
+			}
+
+			for ok := c.SyncCluster(); ok == false; {
+				fmt.Println("SyncCluster failed, trying again")
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			result, err := c.Set("foo", "exp_"+strconv.Itoa(n), 0)
+			if err != nil {
+				fmt.Println("set error", err)
+			} else {
+				fmt.Printf("set %+v\n", result)
+			}
+
+			ss, err := c.Get("foo")
+			if err != nil {
+				fmt.Println("get error", err)
+			} else {
+				fmt.Println(len(ss))
+			}
+
+		}
+	}
+}


### PR DESCRIPTION
SyncCluster wasn't working because the parsing was wrong. The list of 
machines is not "," separated but ", " separated.
