### PR TITLE
Copy store.Response into go-etcd.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,19 @@ func main() {
 	c := etcd.NewClient() // default binds to http://0.0.0.0:4001
 
 	// SET the value "bar" to the key "foo" with zero TTL
-	// returns a: *store.Response
+	// returns a: *Response
 	res, _ := c.Set("foo", "bar", 0)
 	fmt.Printf("set response: %+v\n", res)
 
 	// GET the value that is stored for the key "foo"
-	// return a slice: []*store.Response
+	// return a slice: []*Response
 	values, _ := c.Get("foo")
 	for i, res := range values { // .. and print them out
 		fmt.Printf("[%d] get response: %+v\n", i, res)
 	}
 
 	// DELETE the key "foo"
-	// returns a: *store.Response
+	// returns a: *Response
 	res, _ = c.Delete("foo")
 	fmt.Printf("delete response: %+v\n", res)
 }

--- a/etcd/delete.go
+++ b/etcd/delete.go
@@ -2,13 +2,12 @@ package etcd
 
 import (
 	"encoding/json"
-	"github.com/coreos/etcd/store"
 	"io/ioutil"
 	"net/http"
 	"path"
 )
 
-func (c *Client) Delete(key string) (*store.Response, error) {
+func (c *Client) Delete(key string) (*Response, error) {
 
 	resp, err := c.sendRequest("DELETE", path.Join("keys", key), "")
 
@@ -28,7 +27,7 @@ func (c *Client) Delete(key string) (*store.Response, error) {
 		return nil, handleError(b)
 	}
 
-	var result store.Response
+	var result Response
 
 	err = json.Unmarshal(b, &result)
 

--- a/etcd/get.go
+++ b/etcd/get.go
@@ -2,13 +2,12 @@ package etcd
 
 import (
 	"encoding/json"
-	"github.com/coreos/etcd/store"
 	"io/ioutil"
 	"net/http"
 	"path"
 )
 
-func (c *Client) Get(key string) ([]*store.Response, error) {
+func (c *Client) Get(key string) ([]*Response, error) {
 	logger.Debugf("get %s [%s]", key, c.cluster.Leader)
 	resp, err := c.sendRequest("GET", path.Join("keys", key), "")
 
@@ -36,7 +35,7 @@ func (c *Client) Get(key string) ([]*store.Response, error) {
 // GetTo gets the value of the key from a given machine address.
 // If the given machine is not available it returns an error.
 // Mainly use for testing purpose
-func (c *Client) GetFrom(key string, addr string) ([]*store.Response, error) {
+func (c *Client) GetFrom(key string, addr string) ([]*Response, error) {
 	httpPath := c.createHttpPath(addr, path.Join(version, "keys", key))
 
 	resp, err := c.httpClient.Get(httpPath)
@@ -61,10 +60,10 @@ func (c *Client) GetFrom(key string, addr string) ([]*store.Response, error) {
 }
 
 // Convert byte stream to response.
-func convertGetResponse(b []byte) ([]*store.Response, error) {
+func convertGetResponse(b []byte) ([]*Response, error) {
 
-	var results []*store.Response
-	var result *store.Response
+	var results []*Response
+	var result *Response
 
 	err := json.Unmarshal(b, &result)
 
@@ -76,7 +75,7 @@ func convertGetResponse(b []byte) ([]*store.Response, error) {
 		}
 
 	} else {
-		results = make([]*store.Response, 1)
+		results = make([]*Response, 1)
 		results[0] = result
 	}
 	return results, nil

--- a/etcd/response.go
+++ b/etcd/response.go
@@ -1,0 +1,26 @@
+package etcd
+
+import (
+	"time"
+)
+
+// The response object from the server.
+type Response struct {
+	Action    string `json:"action"`
+	Key       string `json:"key"`
+	Dir       bool   `json:"dir,omitempty"`
+	PrevValue string `json:"prevValue,omitempty"`
+	Value     string `json:"value,omitempty"`
+
+	// If the key did not exist before the action,
+	// this field should be set to true
+	NewKey bool `json:"newKey,omitempty"`
+
+	Expiration *time.Time `json:"expiration,omitempty"`
+
+	// Time to live in second
+	TTL int64 `json:"ttl,omitempty"`
+
+	// The command index of the raft machine when the command is executed
+	Index uint64 `json:"index"`
+}

--- a/etcd/set.go
+++ b/etcd/set.go
@@ -3,14 +3,13 @@ package etcd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/coreos/etcd/store"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
 )
 
-func (c *Client) Set(key string, value string, ttl uint64) (*store.Response, error) {
+func (c *Client) Set(key string, value string, ttl uint64) (*Response, error) {
 	logger.Debugf("set %s, %s, ttl: %d, [%s]", key, value, ttl, c.cluster.Leader)
 	v := url.Values{}
 	v.Set("value", value)
@@ -45,7 +44,7 @@ func (c *Client) Set(key string, value string, ttl uint64) (*store.Response, err
 // SetTo sets the value of the key to a given machine address.
 // If the given machine is not available or is not leader it returns an error
 // Mainly use for testing purpose.
-func (c *Client) SetTo(key string, value string, ttl uint64, addr string) (*store.Response, error) {
+func (c *Client) SetTo(key string, value string, ttl uint64, addr string) (*Response, error) {
 	v := url.Values{}
 	v.Set("value", value)
 
@@ -77,8 +76,8 @@ func (c *Client) SetTo(key string, value string, ttl uint64, addr string) (*stor
 }
 
 // Convert byte stream to response.
-func convertSetResponse(b []byte) (*store.Response, error) {
-	var result store.Response
+func convertSetResponse(b []byte) (*Response, error) {
+	var result Response
 
 	err := json.Unmarshal(b, &result)
 

--- a/etcd/testAndSet.go
+++ b/etcd/testAndSet.go
@@ -3,14 +3,13 @@ package etcd
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/coreos/etcd/store"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
 )
 
-func (c *Client) TestAndSet(key string, prevValue string, value string, ttl uint64) (*store.Response, bool, error) {
+func (c *Client) TestAndSet(key string, prevValue string, value string, ttl uint64) (*Response, bool, error) {
 	logger.Debugf("set %s, %s[%s], ttl: %d, [%s]", key, value, prevValue, ttl, c.cluster.Leader)
 	v := url.Values{}
 	v.Set("value", value)
@@ -39,7 +38,7 @@ func (c *Client) TestAndSet(key string, prevValue string, value string, ttl uint
 		return nil, false, handleError(b)
 	}
 
-	var result store.Response
+	var result Response
 
 	err = json.Unmarshal(b, &result)
 

--- a/etcd/watch.go
+++ b/etcd/watch.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/coreos/etcd/store"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -28,7 +27,7 @@ var (
 // channel. And after someone receive the channel, it will go on to watch that prefix.
 // If a stop channel is given, client can close long-term watch using the stop channel
 
-func (c *Client) Watch(prefix string, sinceIndex uint64, receiver chan *store.Response, stop chan bool) (*store.Response, error) {
+func (c *Client) Watch(prefix string, sinceIndex uint64, receiver chan *Response, stop chan bool) (*Response, error) {
 	logger.Debugf("watch %s [%s]", prefix, c.cluster.Leader)
 	if receiver == nil {
 		return c.watchOnce(prefix, sinceIndex, stop)
@@ -50,7 +49,7 @@ func (c *Client) Watch(prefix string, sinceIndex uint64, receiver chan *store.Re
 
 // helper func
 // return when there is change under the given prefix
-func (c *Client) watchOnce(key string, sinceIndex uint64, stop chan bool) (*store.Response, error) {
+func (c *Client) watchOnce(key string, sinceIndex uint64, stop chan bool) (*Response, error) {
 
 	var resp *http.Response
 	var err error
@@ -94,7 +93,7 @@ func (c *Client) watchOnce(key string, sinceIndex uint64, stop chan bool) (*stor
 		return nil, handleError(b)
 	}
 
-	var result store.Response
+	var result Response
 
 	err = json.Unmarshal(b, &result)
 

--- a/etcd/watch_test.go
+++ b/etcd/watch_test.go
@@ -2,7 +2,6 @@ package etcd
 
 import (
 	"fmt"
-	"github.com/coreos/etcd/store"
 	"testing"
 	"time"
 )
@@ -30,7 +29,7 @@ func TestWatch(t *testing.T) {
 		t.Fatalf("Watch with Index failed with %s %s %v %v", result.Key, result.Value, result.TTL, result.Index)
 	}
 
-	ch := make(chan *store.Response, 10)
+	ch := make(chan *Response, 10)
 	stop := make(chan bool, 1)
 
 	go setLoop("bar", c)
@@ -57,7 +56,7 @@ func setLoop(value string, c *Client) {
 	}
 }
 
-func receiver(c chan *store.Response, stop chan bool) {
+func receiver(c chan *Response, stop chan bool) {
 	for i := 0; i < 10; i++ {
 		<-c
 	}


### PR DESCRIPTION
@xiangli-cmu @philips The `go-etcd` library currently depends on `etcd` in order to use the `store.Response` type. This pull request simply copies the `Response` over to the `go-etcd` library.

Is there a test harness for running the tests? I think we should move these functional tests to the `etcd-test-runner` repo once it's created and just leave unit tests in the repo itself.
