### PR TITLE
Reuse response structure instead of KVPair

### DIFF
--- a/etcd/add_child_test.go
+++ b/etcd/add_child_test.go
@@ -59,7 +59,7 @@ func TestAddChildDir(t *testing.T) {
 	resp, err := c.Get("fooDir", true)
 	// The child with v0 should proceed the child with v1 because it's added
 	// earlier, so it should have a lower key.
-	if !(len(resp.Kvs) == 2 && (len(resp.Kvs[0].KVPairs) == 0 && len(resp.Kvs[1].KVPairs) == 0)) {
+	if !(len(resp.Kvs) == 2 && (len(resp.Kvs[0].Kvs) == 0 && len(resp.Kvs[1].Kvs) == 0)) {
 		t.Fatalf("AddChildDir 1 failed.  There should be two chlidren whose values are v0 and v1, respectively."+
 			"  The response was: %#v", resp)
 	}

--- a/etcd/get_test.go
+++ b/etcd/get_test.go
@@ -47,11 +47,11 @@ func TestGetAll(t *testing.T) {
 	}
 
 	expected := kvPairs{
-		KeyValuePair{
+		&Response{
 			Key:   "/fooDir/k0",
 			Value: "v0",
 		},
-		KeyValuePair{
+		&Response{
 			Key:   "/fooDir/k1",
 			Value: "v1",
 		},
@@ -73,21 +73,21 @@ func TestGetAll(t *testing.T) {
 	}
 
 	expected = kvPairs{
-		KeyValuePair{
+		&Response{
 			Key: "/fooDir/childDir",
 			Dir: true,
-			KVPairs: kvPairs{
-				KeyValuePair{
+			Kvs: kvPairs{
+				&Response{
 					Key:   "/fooDir/childDir/k2",
 					Value: "v2",
 				},
 			},
 		},
-		KeyValuePair{
+		&Response{
 			Key:   "/fooDir/k0",
 			Value: "v0",
 		},
-		KeyValuePair{
+		&Response{
 			Key:   "/fooDir/k1",
 			Value: "v1",
 		},

--- a/etcd/response.go
+++ b/etcd/response.go
@@ -26,15 +26,7 @@ type Response struct {
 	Index uint64 `json:"index"`
 }
 
-// When user list a directory, we add all the node into key-value pair slice
-type KeyValuePair struct {
-	Key     string  `json:"key, omitempty"`
-	Value   string  `json:"value,omitempty"`
-	Dir     bool    `json:"dir,omitempty"`
-	KVPairs kvPairs `json:"kvs,omitempty"`
-}
-
-type kvPairs []KeyValuePair
+type kvPairs []*Response
 
 // interfaces for sorting
 func (kvs kvPairs) Len() int {


### PR DESCRIPTION
Using KVPair makes it hard to write recursive functions that operate on Response.  This PR uses Response in place of KVPair.

The caveat here is that since etcd 0.2 does not return TTLs when listing recursively, the 0-values in the child Responses are misleading.
