### PR TITLE
watchOnce: Avoid defunct goroutine

### DIFF
--- a/etcd/watch.go
+++ b/etcd/watch.go
@@ -56,16 +56,16 @@ func (c *Client) watchOnce(key string, sinceIndex uint64, stop chan bool) (*Resp
 
 	if stop != nil {
 		ch := make(chan respAndErr)
+		fin := make(chan bool)
 
 		go func() {
-			defer func() {
-				if r := recover(); r != nil && resp != nil {
-					resp.Body.Close()
-				}
-			}()
 			resp, err = c.sendWatchRequest(key, sinceIndex)
 
-			ch <- respAndErr{resp, err}
+			select {
+			case ch <- respAndErr{resp, err}:
+			case <-fin:
+				resp.Body.Close()
+			}
 		}()
 
 		// select at stop or continue to receive
@@ -75,8 +75,8 @@ func (c *Client) watchOnce(key string, sinceIndex uint64, stop chan bool) (*Resp
 			resp, err = res.resp, res.err
 
 		case <-stop:
-			close(ch)
-			resp, err = nil, ErrWatchStoppedByUser
+			close(fin)
+			return nil, ErrWatchStoppedByUser
 		}
 	} else {
 		resp, err = c.sendWatchRequest(key, sinceIndex)


### PR DESCRIPTION
Avoid three goroutines to go defunct due to a stop event.
The patch is quite straightforward, there may be a better solution using another channel to avoid panicking.

```
goroutine 1 [running]:
main.main()
    /home/exxo/go-etcd/src/main/main.go:32 +0x284

goroutine 7 [chan receive]:
net/http.(*persistConn).readLoop(0xc2000b8500)
    /usr/lib/go/src/pkg/net/http/transport.go:761 +0x64b
created by net/http.(*Transport).dialConn
    /usr/lib/go/src/pkg/net/http/transport.go:511 +0x574

goroutine 8 [select]:
net/http.(*persistConn).writeLoop(0xc2000b8500)
    /usr/lib/go/src/pkg/net/http/transport.go:774 +0x26f
created by net/http.(*Transport).dialConn
    /usr/lib/go/src/pkg/net/http/transport.go:512 +0x58b

goroutine 10 [chan send]:
etcd.func·001()
    /home/exxo/go-etcd/src/etcd/watch.go:64 +0xd4
created by etcd.(*Client).watchOnce
    /home/exxo/go-etcd/src/etcd/watch.go:65 +0x16c
```
