### PR TITLE
Fix watch operations to be thread safe

### DIFF
--- a/etcd/get.go
+++ b/etcd/get.go
@@ -8,7 +8,9 @@ import (
 )
 
 func (c *Client) Get(key string) ([]*Response, error) {
+	c.cluster.RLock()
 	logger.Debugf("get %s [%s]", key, c.cluster.Leader)
+	c.cluster.RUnlock()
 	resp, err := c.sendRequest("GET", path.Join("keys", key), "")
 
 	if err != nil {

--- a/etcd/set.go
+++ b/etcd/set.go
@@ -10,7 +10,9 @@ import (
 )
 
 func (c *Client) Set(key string, value string, ttl uint64) (*Response, error) {
+	c.cluster.RLock()
 	logger.Debugf("set %s, %s, ttl: %d, [%s]", key, value, ttl, c.cluster.Leader)
+	c.cluster.RUnlock()
 	v := url.Values{}
 	v.Set("value", value)
 

--- a/etcd/testAndSet.go
+++ b/etcd/testAndSet.go
@@ -10,7 +10,9 @@ import (
 )
 
 func (c *Client) TestAndSet(key string, prevValue string, value string, ttl uint64) (*Response, bool, error) {
+	c.cluster.RLock()
 	logger.Debugf("set %s, %s[%s], ttl: %d, [%s]", key, value, prevValue, ttl, c.cluster.Leader)
+	c.cluster.RUnlock()
 	v := url.Values{}
 	v.Set("value", value)
 	v.Set("prevValue", prevValue)

--- a/etcd/watch.go
+++ b/etcd/watch.go
@@ -28,7 +28,9 @@ var (
 // If a stop channel is given, client can close long-term watch using the stop channel
 
 func (c *Client) Watch(prefix string, sinceIndex uint64, receiver chan *Response, stop chan bool) (*Response, error) {
+	c.cluster.RLock()
 	logger.Debugf("watch %s [%s]", prefix, c.cluster.Leader)
+	c.cluster.RUnlock()
 	if receiver == nil {
 		return c.watchOnce(prefix, sinceIndex, stop)
 


### PR DESCRIPTION
Add R/W locks so that the updates on the cluster leader don't cause race conditions when multiple ```Watch``` are done simultaneously.