### PR TITLE
Allow watch on etcd root

### DIFF
--- a/etcd/requests.go
+++ b/etcd/requests.go
@@ -15,7 +15,12 @@ import (
 func (c *Client) get(key string, options options) (*RawResponse, error) {
 	logger.Debugf("get %s [%s]", key, c.cluster.Leader)
 
-	p := path.Join("keys", key)
+	var p string
+	if key == "/" {
+		p = key
+	} else {
+		p = path.Join("keys", key)
+	}
 	// If consistency level is set to STRONG, append
 	// the `consistent` query string.
 	if c.config.Consistency == STRONG_CONSISTENCY {


### PR DESCRIPTION
This fix allows watching etcd root in order to get all notifications, that is, subscribe to every prefixes.
(e.g `curl -L "http://127.0.0.1:4001/v2/keys/?wait=true&recursive=true"`)
