### PR TITLE
Log in case of network error.

### DIFF
--- a/etcd/requests.go
+++ b/etcd/requests.go
@@ -146,6 +146,7 @@ func (c *Client) sendRequest(method string, relativePath string,
 
 		// network error, change a machine!
 		if resp, err = c.httpClient.Do(req); err != nil {
+			logger.Debug("network error: ", err.Error())
 			c.cluster.switchLeader(trial % len(c.cluster.Machines))
 			time.Sleep(time.Millisecond * 200)
 			continue


### PR DESCRIPTION
Log in case of network error.

This log would have helped to debug the case where I forgot to prefix machine addresses with http://
