### PR TITLE
Add cancelable AsyncWatch

### DIFF
--- a/etcd/watch_test.go
+++ b/etcd/watch_test.go
@@ -45,6 +45,61 @@ func TestWatch(t *testing.T) {
 	}
 }
 
+func TestAsyncWatch(t *testing.T) {
+	c := NewClient(nil)
+
+	responseChan, _, errorsChan, err := c.AsyncWatch("watch_baz", 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	setHelper("watch_baz/foo", "bar", c)
+
+	select {
+	case resp := <-responseChan:
+		if !(resp.Node.Key == "/watch_baz/foo" && resp.Node.Value == "bar") {
+			t.Fatalf("Watch failed")
+		}
+	case err := <-errorsChan:
+		t.Fatal(err)
+	case <-time.After(time.Second):
+		t.Fatalf("Timed out waiting for a watch response")
+	}
+
+	responseChan, stop, errorsChan, err := c.AsyncWatch("watch_baz", 0, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(10 * time.Millisecond) //stop only works once the request is in-flight...
+
+	select {
+	case stop <- true:
+	case <-time.After(time.Second):
+		t.Fatalf("Failed to stop....")
+	}
+
+	setHelper("watch_baz/wibble", "blah", c)
+
+	select {
+	case _, open := <-responseChan:
+		if open {
+			t.Fatalf("Expected responseChan to be closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("Expected responseChan to close")
+	}
+
+	select {
+	case _, open := <-errorsChan:
+		if open {
+			t.Fatalf("Expected errorsChan to be closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("Expected errorsChan to close")
+	}
+}
+
 func TestWatchAll(t *testing.T) {
 	c := NewClient(nil)
 	defer func() {


### PR DESCRIPTION
This involved creating an asyncSendRequest on the go-etcd Client object asyncSendRequest returns a stop channel that, when closed, attempts to cancel the connection.

This only works if the connection is in-flight. Which means there is an intrinsic race that cannot be avoided. If stop is called before the innards of c.httpClient.Do(req) have reached the point where the request is registered (and therefore cancelable) then the request will not be cancelled. For short requests this is OK, the request is returned, and we clean up. For long-running requests (e.g. watch) the goroutines spawned by net/http and one go-routine per async call will leak (until the response comes in).

Also: we didn't try changing the behavior of Watch -- we think its interface doesn't quite make sense.  AsyncWatch returns three channels: a response channel, an error channel, and a stop channel, and it leaves looping to obtain subsequent watches by following the index to the caller.

If you'd like to add the latter, we think that AsyncWatch should handle the EventIndexCleared error and do its best to jump to the next available index.  That might make more sense as a separate pull request, though.
