### PR TITLE
Always close response channel when Watch is done.

### DIFF
--- a/etcd/watch.go
+++ b/etcd/watch.go
@@ -33,6 +33,7 @@ func (c *Client) Watch(prefix string, waitIndex uint64, recursive bool,
 
 		return raw.toResponse()
 	}
+	defer close(receiver)
 
 	for {
 		raw, err := c.watchOnce(prefix, waitIndex, recursive, stop)


### PR DESCRIPTION
Added a defer statement when the receiver channel passed to Watch is
set to close the channel. This permits the goroutine consuming that
channel to gracefully terminate when the channel will no longer return
any responses.

This is an implementation of the discussion in #96.
