### PR TITLE
chore(client): always sync cluster when setting client.cluster

### DIFF
--- a/etcd/client.go
+++ b/etcd/client.go
@@ -60,6 +60,7 @@ func NewClient(machines []string) *Client {
 	}
 
 	client.initHTTPClient()
+	client.SyncCluster()
 	client.saveConfig()
 
 	return client
@@ -93,6 +94,7 @@ func NewTLSClient(machines []string, cert, key, caCert string) (*Client, error) 
 	}
 
 	err = client.AddRootCA(caCert)
+	client.SyncCluster()
 
 	client.saveConfig()
 
@@ -253,6 +255,12 @@ func (c *Client) AddRootCA(caCert string) error {
 	c.saveConfig()
 
 	return err
+}
+
+// SetRawCluster sets cluster information using the given machine list
+// without sync.
+func (c *Client) SetRawCluster(machines []string) {
+	c.cluster.Machines = machines
 }
 
 // SetCluster updates cluster information using the given machine list.


### PR DESCRIPTION
Or it may be set as wrong cluster information.

Add SetRawCluster as the interface to set cluster directly.

@xiangli-cmu