### PR TITLE
Make Nodes be a slice of pointers so that we can implement a fake versio...

### DIFF
--- a/etcd/get_test.go
+++ b/etcd/get_test.go
@@ -18,9 +18,9 @@ func cleanResult(result *Response) {
 	//  TODO(philips): make this recursive.
 	cleanNode(result.Node)
 	for i, _ := range result.Node.Nodes {
-		cleanNode(&result.Node.Nodes[i])
+		cleanNode(result.Node.Nodes[i])
 		for j, _ := range result.Node.Nodes[i].Nodes {
-			cleanNode(&result.Node.Nodes[i].Nodes[j])
+			cleanNode(result.Node.Nodes[i].Nodes[j])
 		}
 	}
 }
@@ -67,12 +67,12 @@ func TestGetAll(t *testing.T) {
 	}
 
 	expected := Nodes{
-		Node{
+		&Node{
 			Key:   "/fooDir/k0",
 			Value: "v0",
 			TTL:   5,
 		},
-		Node{
+		&Node{
 			Key:   "/fooDir/k1",
 			Value: "v1",
 			TTL:   5,
@@ -99,11 +99,11 @@ func TestGetAll(t *testing.T) {
 	}
 
 	expected = Nodes{
-		Node{
+		&Node{
 			Key: "/fooDir/childDir",
 			Dir: true,
 			Nodes: Nodes{
-				Node{
+				&Node{
 					Key:   "/fooDir/childDir/k2",
 					Value: "v2",
 					TTL:   5,
@@ -111,12 +111,12 @@ func TestGetAll(t *testing.T) {
 			},
 			TTL: 5,
 		},
-		Node{
+		&Node{
 			Key:   "/fooDir/k0",
 			Value: "v0",
 			TTL:   5,
 		},
-		Node{
+		&Node{
 			Key:   "/fooDir/k1",
 			Value: "v1",
 			TTL:   5,

--- a/etcd/response.go
+++ b/etcd/response.go
@@ -73,7 +73,7 @@ type Node struct {
 	CreatedIndex  uint64     `json:"createdIndex,omitempty"`
 }
 
-type Nodes []Node
+type Nodes []*Node
 
 // interfaces for sorting
 func (ns Nodes) Len() int {


### PR DESCRIPTION
Make Nodes be a slice of pointers so that [Flynn](https://flynn.io/) can implement a fake version of etcd for tests that use Node internally as the type for the tree of data stored: https://github.com/flynn/strowger/blob/a59db1f76f71a7439f71ae3aec552888f074e34f/setup_test.go#L31

Flynn has currently forked go-etcd with its own version, but I'd like to get them using the upstream again if possible. See here https://github.com/flynn/flynn-host/issues/14
