### PR TITLE
go vet fixes

### DIFF
--- a/etcd/client.go
+++ b/etcd/client.go
@@ -33,7 +33,7 @@ type Config struct {
 	KeyFile     string        `json:"keyFile"`
 	CaCertFile  []string      `json:"caCertFiles"`
 	DialTimeout time.Duration `json:"timeout"`
-	Consistency string        `json: "consistency"`
+	Consistency string        `json:"consistency"`
 }
 
 type Client struct {
@@ -416,8 +416,8 @@ func (c *Client) MarshalJSON() ([]byte, error) {
 // as defined by the standard JSON package.
 func (c *Client) UnmarshalJSON(b []byte) error {
 	temp := struct {
-		Config  Config   `json: "config"`
-		Cluster *Cluster `json: "cluster"`
+		Config  Config   `json:"config"`
+		Cluster *Cluster `json:"cluster"`
 	}{}
 	err := json.Unmarshal(b, &temp)
 	if err != nil {

--- a/etcd/watch.go
+++ b/etcd/watch.go
@@ -51,8 +51,6 @@ func (c *Client) Watch(prefix string, waitIndex uint64, recursive bool,
 		waitIndex = resp.Node.ModifiedIndex + 1
 		receiver <- resp
 	}
-
-	return nil, nil
 }
 
 func (c *Client) RawWatch(prefix string, waitIndex uint64, recursive bool,
@@ -79,8 +77,6 @@ func (c *Client) RawWatch(prefix string, waitIndex uint64, recursive bool,
 		waitIndex = resp.Node.ModifiedIndex + 1
 		receiver <- raw
 	}
-
-	return nil, nil
 }
 
 // helper func


### PR DESCRIPTION
`go vet` had a few complaints:

```
client.go:36: struct field tag `json: "consistency"` not compatible with reflect.StructTag.Get
client.go:419: struct field tag `json: "config"` not compatible with reflect.StructTag.Get
client.go:420: struct field tag `json: "cluster"` not compatible with reflect.StructTag.Get
watch.go:55: unreachable code
watch.go:83: unreachable code
```

Do you care about go 1.0 still?
