### PR TITLE
Enhanced keyToPath() to URL-escape keys

### DIFF
--- a/etcd/requests.go
+++ b/etcd/requests.go
@@ -354,11 +354,13 @@ func buildValues(value string, ttl uint64) url.Values {
 	return v
 }
 
-// convert key string to http path exclude version
+// convert key string to http path exclude version, including URL escaping
 // for example: key[foo] -> path[keys/foo]
+// key[/%z] -> path[keys/%25z]
 // key[/] -> path[keys/]
 func keyToPath(key string) string {
-	p := path.Join("keys", key)
+	// URL-escape our key, except for slashes
+	p := strings.Replace(url.QueryEscape(path.Join("keys", key)), "%2F", "/", -1)
 
 	// corner case: if key is "/" or "//" ect
 	// path join will clear the tailing "/"


### PR DESCRIPTION
Hi, I submitted [an issue to coreos/etcdctl](https://github.com/coreos/etcdctl/issues/81) where keys were not being URL-encoded when making HTTP requests.  I tracked the issue to the [keyToPath()](https://github.com/tedb/go-etcd/blob/master/etcd/requests.go#L361) function within go-etcd/etc/requests.go, and this pull request adds escaping of keys when converting to a URL path.
