### PR TITLE
requests: check stop chan if fail to read from response body

### DIFF
--- a/etcd/requests.go
+++ b/etcd/requests.go
@@ -268,6 +268,12 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 				logger.Debug("recv.success.", httpPath)
 				break
 			}
+			// ReadAll error may be caused due to cancel request
+			select {
+			case <-cancelled:
+				return nil, ErrRequestCancelled
+			default:
+			}
 		}
 
 		// if resp is TemporaryRedirect, set the new leader and retry


### PR DESCRIPTION
The failure on reading from response body may be caused because user
has asked to cancel http requests. So we check the stop chan status
to return correct error.
#146

@marc-barry: I cannot replay your case that it cannot stop requests. I am using the +git version of etcd and go-etcd. I hope this one could help.
fixes coreos/etcd#901
@onsi: It fixes the wrong error problem in your script well.
