### PR TITLE
debug.go using fmt.Sprintf incorrectly

### DIFF
--- a/etcd/debug.go
+++ b/etcd/debug.go
@@ -22,12 +22,12 @@ type etcdLogger struct {
 }
 
 func (p *etcdLogger) Debug(args ...interface{}) {
-	msg := "DEBUG: " + fmt.Sprint(args)
+	msg := "DEBUG: " + fmt.Sprint(args...)
 	p.log.Println(msg)
 }
 
 func (p *etcdLogger) Debugf(f string, args ...interface{}) {
-	msg := "DEBUG: " + fmt.Sprintf(f, args)
+	msg := "DEBUG: " + fmt.Sprintf(f, args...)
 	// Append newline if necessary
 	if !strings.HasSuffix(msg, "\n") {
 		msg = msg + "\n"
@@ -36,12 +36,12 @@ func (p *etcdLogger) Debugf(f string, args ...interface{}) {
 }
 
 func (p *etcdLogger) Warning(args ...interface{}) {
-	msg := "WARNING: " + fmt.Sprint(args)
+	msg := "WARNING: " + fmt.Sprint(args...)
 	p.log.Println(msg)
 }
 
 func (p *etcdLogger) Warningf(f string, args ...interface{}) {
-	msg := "WARNING: " + fmt.Sprintf(f, args)
+	msg := "WARNING: " + fmt.Sprintf(f, args...)
 	// Append newline if necessary
 	if !strings.HasSuffix(msg, "\n") {
 		msg = msg + "\n"


### PR DESCRIPTION
right now, it prints:
  DEBUG: watch [/service1 http://127.0.0.1:4001] [%!s(MISSING)]

update below:
fmt.Sprintf(f, args)        ---------->      fmt.Sprintf(f, args...)

then it's ok:
 DEBUG: get /service1 [http://127.0.0.1:4001]
