### PR TITLE
Remove erroneous statements from RawWatch

### DIFF
--- a/etcd/watch.go
+++ b/etcd/watch.go
@@ -68,13 +68,6 @@ func (c *Client) RawWatch(prefix string, waitIndex uint64, recursive bool,
 			return nil, err
 		}
 
-		resp, err := raw.Unmarshal()
-
-		if err != nil {
-			return nil, err
-		}
-
-		waitIndex = resp.Node.ModifiedIndex + 1
 		receiver <- raw
 	}
 }


### PR DESCRIPTION
The return type of `client.Watch` is `*etcd.Response`. This method will either wait for the first etcd event and return it or continuously send new events on the provided channel until instructed otherwise. In both cases, an `*etcd.Response` is created by parsing the JSON response from etcd.

Unfortunately, `client.RawWatch` is inconsistent with this behavior. If no receiver channel is provided, it will return an `*etcd.RawResponse` when the first event occurs.  However, if a channel is provided, it will attempt to unmarshal the raw response and exit if an error occurs. This appears to be an error - which is further confirmed by the fact that `resp` is [assigned to but never used](https://github.com/coreos/go-etcd/blob/92e855b1a85671af2c58e4353cb277687965a5fa/etcd/watch.go#L65):

    raw, err := c.watchOnce(prefix, waitIndex, recursive, stop)

    if err != nil {
        return nil, err
    }

    resp, err := raw.Unmarshal()

    if err != nil {
        return nil, err
    }

    waitIndex = resp.Node.ModifiedIndex + 1
    receiver <- raw

My pull request removes the additional lines, since I can only assume that if someone wanted the response processed, they would have used `Watch` instead of `RawWatch`.