### PR TITLE
Add Put as a thin wrapper around raw put

### DIFF
--- a/etcd/put.go
+++ b/etcd/put.go
@@ -1,0 +1,12 @@
+package etcd
+
+// Put issues a PUT request
+func (c *Client) Put(key string, value string, ttl uint64,
+	options Options) (*Response, error) {
+	raw, err := c.put(key, value, ttl, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return raw.Unmarshal()
+}

--- a/etcd/put_test.go
+++ b/etcd/put_test.go
@@ -1,0 +1,57 @@
+package etcd
+
+import (
+	"testing"
+)
+
+func TestPut(t *testing.T) {
+	c := NewClient(nil)
+	defer func() {
+		c.Delete("foo", true)
+	}()
+
+	c.Put("foo", "bar", 5, Options{})
+
+	// This should succeed
+	resp, err := c.Put("foo", "bar2", 5, Options{"prevValue": "bar"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !(resp.Node.Value == "bar2" && resp.Node.Key == "/foo" && resp.Node.TTL == 5) {
+		t.Fatalf("CompareAndSwap 1 failed: %#v", resp)
+	}
+
+	if !(resp.PrevNode.Value == "bar" && resp.PrevNode.Key == "/foo" && resp.PrevNode.TTL == 5) {
+		t.Fatalf("CompareAndSwap 1 prevNode failed: %#v", resp)
+	}
+
+	// This should fail because it gives an incorrect prevValue
+	resp, err = c.Put("foo", "bar2", 5, Options{"prevValue": "xxx"})
+	if err == nil {
+		t.Fatalf("CompareAndSwap 2 should have failed.  The response is: %#v", resp)
+	}
+
+	resp, err = c.Put("foo", "bar", 5, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This should succeed
+	resp, err = c.Put("foo", "bar2", 5, Options{"prevIndex": resp.Node.ModifiedIndex})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !(resp.Node.Value == "bar2" && resp.Node.Key == "/foo" && resp.Node.TTL == 5) {
+		t.Fatalf("CompareAndSwap 3 failed: %#v", resp)
+	}
+
+	if !(resp.PrevNode.Value == "bar" && resp.PrevNode.Key == "/foo" && resp.PrevNode.TTL == 5) {
+		t.Fatalf("CompareAndSwap 3 prevNode failed: %#v", resp)
+	}
+
+	// This should fail because it gives an incorrect prevIndex
+	resp, err = c.Put("foo", "bar2", 5, Options{"prevIndex": 29817514})
+	if err == nil {
+		t.Fatalf("CompareAndSwap 4 should have failed.  The response is: %#v", resp)
+	}
+}

--- a/etcd/put_test.go
+++ b/etcd/put_test.go
@@ -18,17 +18,17 @@ func TestPut(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !(resp.Node.Value == "bar2" && resp.Node.Key == "/foo" && resp.Node.TTL == 5) {
-		t.Fatalf("CompareAndSwap 1 failed: %#v", resp)
+		t.Fatalf("Put 1 failed: %#v", resp)
 	}
 
 	if !(resp.PrevNode.Value == "bar" && resp.PrevNode.Key == "/foo" && resp.PrevNode.TTL == 5) {
-		t.Fatalf("CompareAndSwap 1 prevNode failed: %#v", resp)
+		t.Fatalf("Put 1 prevNode failed: %#v", resp)
 	}
 
 	// This should fail because it gives an incorrect prevValue
 	resp, err = c.Put("foo", "bar2", 5, Options{"prevValue": "xxx"})
 	if err == nil {
-		t.Fatalf("CompareAndSwap 2 should have failed.  The response is: %#v", resp)
+		t.Fatalf("Put 2 should have failed.  The response is: %#v", resp)
 	}
 
 	resp, err = c.Put("foo", "bar", 5, Options{})
@@ -42,16 +42,16 @@ func TestPut(t *testing.T) {
 		t.Fatal(err)
 	}
 	if !(resp.Node.Value == "bar2" && resp.Node.Key == "/foo" && resp.Node.TTL == 5) {
-		t.Fatalf("CompareAndSwap 3 failed: %#v", resp)
+		t.Fatalf("Put 3 failed: %#v", resp)
 	}
 
 	if !(resp.PrevNode.Value == "bar" && resp.PrevNode.Key == "/foo" && resp.PrevNode.TTL == 5) {
-		t.Fatalf("CompareAndSwap 3 prevNode failed: %#v", resp)
+		t.Fatalf("Put 3 prevNode failed: %#v", resp)
 	}
 
 	// This should fail because it gives an incorrect prevIndex
 	resp, err = c.Put("foo", "bar2", 5, Options{"prevIndex": 29817514})
 	if err == nil {
-		t.Fatalf("CompareAndSwap 4 should have failed.  The response is: %#v", resp)
+		t.Fatalf("Put 4 should have failed.  The response is: %#v", resp)
 	}
 }


### PR DESCRIPTION
I have a couple of use cases where I have to currently decide which function to call (Set vs Update vs Create vs CompareAndSwap) where just conditionally setting the options to PUT is much cleaner.