### PR TITLE
Off by one error with default retry policy. With a single machine list i...

### DIFF
--- a/etcd/requests.go
+++ b/etcd/requests.go
@@ -333,7 +333,7 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 func DefaultCheckRetry(cluster *Cluster, numReqs int, lastResp http.Response,
 	err error) error {
 
-	if numReqs >= 2*len(cluster.Machines) {
+	if numReqs > 2*len(cluster.Machines) {
 		return newError(ErrCodeEtcdNotReachable,
 			"Tried to connect to each peer twice and failed", 0)
 	}


### PR DESCRIPTION
...t only attempts to connect once, not twice because the numReqs starts at 1 and is incremented before the check