### PR TITLE
Fix panic due to index out of range

### DIFF
--- a/etcd/cluster.go
+++ b/etcd/cluster.go
@@ -30,5 +30,5 @@ func (cl *Cluster) pick() string { return cl.Machines[cl.picked] }
 
 func (cl *Cluster) updateFromStr(machines string) {
 	cl.Machines = strings.Split(machines, ",")
-	cl.picked = rand.Intn(len(machines))
+	cl.picked = rand.Intn(len(cl.Machines))
 }


### PR DESCRIPTION
udpateFromStr is using the length of the string when randomly choosing a machine. It should have been the length of the slice.