### PR TITLE
Add support for prevExist parameter in CompareAndSwap

### DIFF
--- a/etcd/compare_and_swap_test.go
+++ b/etcd/compare_and_swap_test.go
@@ -13,7 +13,7 @@ func TestCompareAndSwap(t *testing.T) {
 	c.Set("foo", "bar", 5)
 
 	// This should succeed
-	resp, err := c.CompareAndSwap("foo", "bar2", 5, "bar", 0)
+	resp, err := c.CompareAndSwap("foo", "bar2", 5, "bar", 0, Ignored)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +26,7 @@ func TestCompareAndSwap(t *testing.T) {
 	}
 
 	// This should fail because it gives an incorrect prevValue
-	resp, err = c.CompareAndSwap("foo", "bar3", 5, "xxx", 0)
+	resp, err = c.CompareAndSwap("foo", "bar3", 5, "xxx", 0, Ignored)
 	if err == nil {
 		t.Fatalf("CompareAndSwap 2 should have failed.  The response is: %#v", resp)
 	}
@@ -37,7 +37,7 @@ func TestCompareAndSwap(t *testing.T) {
 	}
 
 	// This should succeed
-	resp, err = c.CompareAndSwap("foo", "bar2", 5, "", resp.Node.ModifiedIndex)
+	resp, err = c.CompareAndSwap("foo", "bar2", 5, "", resp.Node.ModifiedIndex, Ignored)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,8 +50,21 @@ func TestCompareAndSwap(t *testing.T) {
 	}
 
 	// This should fail because it gives an incorrect prevIndex
-	resp, err = c.CompareAndSwap("foo", "bar3", 5, "", 29817514)
+	resp, err = c.CompareAndSwap("foo", "bar3", 5, "", 29817514, Ignored)
 	if err == nil {
 		t.Fatalf("CompareAndSwap 4 should have failed.  The response is: %#v", resp)
+	}
+
+    // This should fail because the key already exists
+	resp, err = c.CompareAndSwap("foo", "bar4", 5, "", 0, DoesNotExist)
+	if err == nil {
+		t.Fatalf("CompareAndSwap 5 should have failed. The response is %#v", resp)
+	}
+
+	// This should succeed
+	c.Set("foo", "bar", 5)
+	resp, err = c.CompareAndSwap("foo", "bar5", 5, "", 0, Exists)
+	if err != nil {
+		t.Fatalf("CompareAndSwap 6 failed: %#v %#v", resp, err)
 	}
 }


### PR DESCRIPTION
I expect there's a better way to accomplish this, I'm pretty new to using Go. 

I'm looking to utilise the CompareAndSwap functionality to create a new key only if it doesn't exist. I've added tests for this addition, but let me know if there's anything else you'd like to see. 

Thanks, Toby. 