### PR TITLE
requests: not cancel request twice to avoid panic

### DIFF
--- a/etcd/requests.go
+++ b/etcd/requests.go
@@ -161,19 +161,9 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 				return
 			}
 
-			// Repeat canceling request until this thread is stopped
-			// because we have no idea about whether it succeeds.
-			for {
-				reqLock.Lock()
-				c.httpClient.Transport.(*http.Transport).CancelRequest(req)
-				reqLock.Unlock()
-
-				select {
-				case <-time.After(100 * time.Millisecond):
-				case <-cancelRoutine:
-					return
-				}
-			}
+			reqLock.Lock()
+			c.httpClient.Transport.(*http.Transport).CancelRequest(req)
+			reqLock.Unlock()
 		}()
 	}
 
@@ -239,6 +229,16 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 
 		if err != nil {
 			return nil, err
+		}
+
+		// If the request is cancelled, return ErrRequestCancelled directly.
+		// Do the check here to minimize the time between checking cancelled
+		// and Do request. This reduces the possibility that the request fails
+		// to be cancelled because cancel happens before Do is called.
+		select {
+		case <-cancelled:
+			return nil, ErrRequestCancelled
+		default:
 		}
 
 		resp, err = c.httpClient.Do(req)


### PR DESCRIPTION
for #197 

CancelRequst twice invokes panic. Ensure the cancel has effect as much as possible.