### PR TITLE
client.go: member/machine endpoint fallback

### DIFF
--- a/etcd/cluster.go
+++ b/etcd/cluster.go
@@ -30,5 +30,8 @@ func (cl *Cluster) pick() string { return cl.Machines[cl.picked] }
 
 func (cl *Cluster) updateFromStr(machines string) {
 	cl.Machines = strings.Split(machines, ",")
+	for i := range cl.Machines {
+		cl.Machines[i] = strings.TrimSpace(cl.Machines[i])
+	}
 	cl.picked = rand.Intn(len(cl.Machines))
 }


### PR DESCRIPTION
To support old cluster, we need to support old machine endpoint.
If we cannot successfully get the response body from the member endpoint,
we try machine endpoint.

Note: This is not a version negotiation. Although the new client supports old cluster, there
might be performance decreases due to lack of leader tracking when operates on old cluster.