### PR TITLE
requests.go: set url.Error into connection error set

### DIFF
--- a/etcd/requests.go
+++ b/etcd/requests.go
@@ -360,7 +360,9 @@ func isEmptyResponse(r http.Response) bool { return r.StatusCode == 0 }
 
 func isConnectionError(err error) bool {
 	_, ok := err.(*net.OpError)
-	return ok
+	// dial may return url error
+	_, ok2 := err.(*url.Error)
+	return ok || ok2
 }
 
 // shouldRetry returns whether the reponse deserves retry.


### PR DESCRIPTION
When send requests to unlistened localhost port, it receives error:
```
Put http://127.0.0.1:9903/v2/keys/foo: dial tcp 127.0.0.1:9903:
connection refused
```
with type *url.Error

Set url.Error into connection error set, so defaultCheckRetry skips
this error and retry instead of stalling.

/cc @xiang90 @philips 