### PR TITLE
README: add caveat part to clarify the boundary of go-etcd

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ func main() {
 go get github.com/coreos/go-etcd/etcd
 ```
 
+## Caveat
+
+1. go-etcd always talks to one member if the member works well. This saves socket resources, and improves efficiency for both client and server side. It doesn't hurt the consistent view of the client because each etcd member has data replication.
+
+2. go-etcd does round-robin rotation when it fails to connect the member in use. For example, if the member that go-etcd connects to is hard killed, go-etcd will fail on the first attempt with the killed member, and succeed on the second attempt with another member. The default CheckRetry function does 2*machine_number retries before returning error.
+
+3. The default transport in go-etcd sets 1s DialTimeout and 1s TCP keepalive period. A customized transport could be set by calling `Client.SetTransport`.
+
+4. Default go-etcd cannot handle the case that the remote server is SIGSTOPed now. TCP keepalive mechanism doesn't help in this scenario because operating system may still send TCP keep-alive packets. We will improve it, but it is not in high priority because we don't see a solid real-life case which server is stopped but connection is alive.
+
+5. go-etcd is not thread-safe, and it may have race when switching member or updating cluster.
+
+6. go-etcd cannot detect whether the member in use is healthy when doing read requests. If the member is isolated from the cluster, go-etcd may retrieve outdated data. We will improve this.
+
 ## License
 
 See LICENSE file.


### PR DESCRIPTION
helps https://github.com/coreos/etcd/issues/2677
helps https://github.com/GoogleCloudPlatform/kubernetes/issues/7566

feedback is welcomed.

/cc @xiang90 