### PR TITLE
Don't attempt to retry canceling a request

### DIFF
--- a/etcd/requests.go
+++ b/etcd/requests.go
@@ -152,19 +152,11 @@ func (c *Client) SendRequest(rr *RawRequest) (*RawResponse, error) {
 				return
 			}
 
-			// Repeat canceling request until this thread is stopped
-			// because we have no idea about whether it succeeds.
-			for {
-				reqLock.Lock()
-				c.httpClient.Transport.(*http.Transport).CancelRequest(req)
-				reqLock.Unlock()
 
-				select {
-				case <-time.After(100 * time.Millisecond):
-				case <-cancelRoutine:
-					return
-				}
-			}
+			// Cancel once and return. This is a "best effort", as multiple calls to CancelRequest are unsafe
+			reqLock.Lock()
+			c.httpClient.Transport.(*http.Transport).CancelRequest(req)
+			reqLock.Unlock()
 		}()
 	}
 


### PR DESCRIPTION
We hit a panic and noticed this retry logic runs afoul of the actual Http transport.

This change simply calls cancel once.

See https://github.com/golang/go/blob/release-branch.go1.4/src/net/http/transport.go#L517

```
panic: close of closed channel

goroutine 531391 [running]:
net/http.func·018()
    /usr/local/go/src/net/http/transport.go:517 +0x2a
net/http.(*Transport).CancelRequest(0x1a52a40, 0xc311d0fad0)
    /usr/local/go/src/net/http/transport.go:284 +0x97
github.com/coreos/go-etcd/etcd.func·003()
    /home/*/go/src/github.com/coreos/go-etcd/etcd/requests.go:159 +0x236
created by github.com/coreos/go-etcd/etcd.(*Client).SendRequest
    /home/*/go/src/github.com/coreos/go-etcd/etcd/requests.go:168 +0x3e3
```