### PR TITLE
Add a LinearizedGet()

### DIFF
--- a/etcd/get.go
+++ b/etcd/get.go
@@ -8,7 +8,17 @@ package etcd
 // will not be returned.
 // If recursive is set to true, all the contents will be returned.
 func (c *Client) Get(key string, sort, recursive bool) (*Response, error) {
-	raw, err := c.RawGet(key, sort, recursive)
+	raw, err := c.RawGet(key, sort, recursive, false)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return raw.Unmarshal()
+}
+// aka GET with 'quorum=true'
+func (c *Client) LinearizedGet(key string, sort, recursive bool) (*Response, error) {
+	raw, err := c.RawGet(key, sort, recursive, true)
 
 	if err != nil {
 		return nil, err
@@ -17,11 +27,9 @@ func (c *Client) Get(key string, sort, recursive bool) (*Response, error) {
 	return raw.Unmarshal()
 }
 
-func (c *Client) RawGet(key string, sort, recursive bool) (*RawResponse, error) {
-	var q bool
-	if c.config.Consistency == STRONG_CONSISTENCY {
-		q = true
-	}
+func (c *Client) RawGet(key string, sort, recursive bool, quorum bool) (*RawResponse, error) {
+	q := (c.config.Consistency == STRONG_CONSISTENCY) || quorum
+
 	ops := Options{
 		"recursive": recursive,
 		"sorted":    sort,


### PR DESCRIPTION
For some reason I would like to use linearized (aka strong consistent / quorum=true) get temporarily..

The case is

1. Set a `/dir/a_key`
2. Get `/dir` recursively

We might have set on the leader but get from a follower who is behind the leader.