### PR TITLE
rely on net.Dialer to set keepalives and ignore the errors

### DIFF
--- a/etcd/client.go
+++ b/etcd/client.go
@@ -394,26 +394,12 @@ func (c *Client) createHttpPath(serverName string, _path string) string {
 // DefaultDial attempts to open a TCP connection to the provided address, explicitly
 // enabling keep-alives with a one-second interval.
 func (c *Client) DefaultDial(network, addr string) (net.Conn, error) {
-	conn, err := net.DialTimeout(network, addr, c.config.DialTimeout)
-	if err != nil {
-		return nil, err
+	dialer := net.Dialer{
+		Timeout:   c.config.DialTimeout,
+		KeepAlive: time.Second,
 	}
 
-	tcpConn, ok := conn.(*net.TCPConn)
-	if !ok {
-		return nil, errors.New("Failed type-assertion of net.Conn as *net.TCPConn")
-	}
-
-	// Keep TCP alive to check whether or not the remote machine is down
-	if err = tcpConn.SetKeepAlive(true); err != nil {
-		return nil, err
-	}
-
-	if err = tcpConn.SetKeepAlivePeriod(time.Second); err != nil {
-		return nil, err
-	}
-
-	return tcpConn, nil
+	return dialer.Dial(network, addr)
 }
 
 func (c *Client) OpenCURL() {


### PR DESCRIPTION
this fixes go-etcd on OpenBSD, which always returns syscall.ENOPROTOOPT
for keepalive functions.