### PR TITLE
client: Check HTTP Response code on Sync Cluster fallback to old API

### DIFF
--- a/etcd/client.go
+++ b/etcd/client.go
@@ -337,6 +337,9 @@ func (c *Client) internalSyncCluster(machines []string) bool {
 				// try another machine in the cluster
 				continue
 			}
+			if resp.StatusCode != http.StatusOK {
+				continue
+			}
 			members = string(b)
 		} else {
 			b, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Currently if you are using `etcd` in proxy mode, and its returning 501s because it can't reach the rest of the cluster, a call to `client.SyncCluster()` will break the client....  `client.GetCluster()` will return `{"message":"proxy: zero endpoints currently available"}` as the cluster list.... Which is pretty wrong.

