### PR TITLE
client: Make initHTTPSClient set client.transport

### DIFF
--- a/etcd/client.go
+++ b/etcd/client.go
@@ -216,12 +216,12 @@ func (c *Client) initHTTPSClient(cert, key string) error {
 		InsecureSkipVerify: true,
 	}
 
-	tr := &http.Transport{
+	c.transport = &http.Transport{
 		TLSClientConfig: tlsConfig,
 		Dial:            c.DefaultDial,
 	}
 
-	c.httpClient = &http.Client{Transport: tr}
+	c.httpClient = &http.Client{Transport: c.transport}
 	return nil
 }
 


### PR DESCRIPTION
This matches the behavior of initHTTPClient.

`client.Close()` assumes that `client.transport` is set to non-nil, but this is only true in the HTTP case -- in the HTTPS case, it is nil, and calling it would cause a nil-pointer dereference.
