### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/etcd/add_child.go
+++ b/etcd/add_child.go
@@ -1,6 +1,6 @@
 package etcd
 
-// Add a new directory with a random etcd-generated key under the given path.
+// AddChildDir adds a new directory with a random etcd-generated key under the given path.
 func (c *Client) AddChildDir(key string, ttl uint64) (*Response, error) {
 	raw, err := c.post(key, "", ttl)
 
@@ -11,7 +11,7 @@ func (c *Client) AddChildDir(key string, ttl uint64) (*Response, error) {
 	return raw.Unmarshal()
 }
 
-// Add a new file with a random etcd-generated key under the given path.
+// AddChild adds a new file with a random etcd-generated key under the given path.
 func (c *Client) AddChild(key string, value string, ttl uint64) (*Response, error) {
 	raw, err := c.post(key, value, ttl)
 

--- a/etcd/client.go
+++ b/etcd/client.go
@@ -174,7 +174,7 @@ func NewClientFromReader(reader io.Reader) (*Client, error) {
 	return c, nil
 }
 
-// Override the Client's HTTP Transport object
+// SetTransport: Override the Client's HTTP Transport object
 func (c *Client) SetTransport(tr *http.Transport) {
 	c.httpClient.Transport = tr
 	c.transport = tr
@@ -252,7 +252,7 @@ func (c *Client) SetConsistency(consistency string) error {
 	return nil
 }
 
-// Sets the DialTimeout value
+// SetDialTimeout: Sets the DialTimeout value
 func (c *Client) SetDialTimeout(d time.Duration) {
 	c.config.DialTimeout = d
 }

--- a/etcd/response.go
+++ b/etcd/response.go
@@ -79,7 +79,7 @@ type Node struct {
 
 type Nodes []*Node
 
-// interfaces for sorting
+// Len: interfaces for sorting
 func (ns Nodes) Len() int {
 	return len(ns)
 }

--- a/etcd/watch.go
+++ b/etcd/watch.go
@@ -9,7 +9,7 @@ var (
 	ErrWatchStoppedByUser = errors.New("Watch stopped by the user via stop channel")
 )
 
-// If recursive is set to true the watch returns the first change under the given
+// Watch: If recursive is set to true the watch returns the first change under the given
 // prefix since the given index.
 //
 // If recursive is set to false the watch returns the first change to the given key


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, *but this is automated so feel free to close it and just say "opt out" to opt out of future CodeLingo outreach PRs.*